### PR TITLE
Check saver process exit code

### DIFF
--- a/tools/checkpoint/util.py
+++ b/tools/checkpoint/util.py
@@ -147,7 +147,9 @@ def main() -> None:
 
     print("Waiting for saver to complete...")
     saver_proc.join()
-
+    if saver_proc.exitcode != 0:
+        print(f"Saver process failed with exit code {saver_proc.exitcode}")
+        exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
https://github.com/llm-jp/modelwg
こちらでMegatron-Llama2の `tools/checkpoint/util.py` を利用しているんですが、`util.py`内で起動している`saver_process`がメモリ不足などの理由で成功せずに終了した場合でも`util.py`がexit code 0で終了するようになっており、その問題を修正しました

参考：
- [`multiprocessing.Process.join()`の仕様](https://docs.python.org/ja/3/library/multiprocessing.html#multiprocessing.Process.join)
  - joinでは終了コードの検査はせず、exitcodeというプロパティを参照する必要があるようです
- [`modelwg`リポジトリでの利用箇所](https://github.com/llm-jp/modelwg/blob/1469280c6ff70f900238e4c5ecf1ed802bf183b8/convert_megatron_to_hf_llama.sh#L23)
